### PR TITLE
fix: memory leaks

### DIFF
--- a/lib/ui/widgets/async_button.dart
+++ b/lib/ui/widgets/async_button.dart
@@ -44,7 +44,7 @@ class _AsyncLoonoButtonState extends State<AsyncLoonoButton> {
           ? () async {
               setState(() => _isLoading = true);
               final asyncResult = await widget.asyncCallback();
-              setState(() => _isLoading = false);
+              if (mounted) setState(() => _isLoading = false);
               if (asyncResult == true) {
                 widget.onSuccess?.call();
               } else if (asyncResult == false) {
@@ -116,7 +116,7 @@ class _AsyncLoonoApiButtonState extends State<AsyncLoonoApiButton> {
           ? () async {
               setState(() => _isLoading = true);
               await widget.asyncCallback();
-              setState(() => _isLoading = false);
+              if (mounted) setState(() => _isLoading = false);
             }
           : null,
       splashColor: widget.enabled ? null : Colors.transparent,
@@ -183,7 +183,7 @@ class _AsyncLoonoLightApiButtonState extends State<AsyncLoonoLightApiButton> {
           ? () async {
               setState(() => _isLoading = true);
               await widget.asyncCallback();
-              setState(() => _isLoading = false);
+              if (mounted) setState(() => _isLoading = false);
             }
           : null,
       splashColor: widget.enabled ? null : Colors.transparent,


### PR DESCRIPTION
neprochazi kvuli tomu test viz Firebase Test Lab logy
```dart
java.lang.Exception: ══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞═════════════════
The following assertion was thrown running a test:
setState() called after dispose():
_AsyncLoonoLightApiButtonState#42770(lifecycle state: defunct,
not mounted)
This error happens if you call setState() on a State object for a
widget that no longer appears in the widget tree (e.g., whose
parent widget no longer includes the widget in its build). This
error can occur when code calls setState() from a timer or an
animation callback.
The preferred solution is to cancel the timer or stop listening
to the animation in the dispose() callback. Another solution is
to check the "mounted" property of this object before calling
setState() to ensure the object is still in the tree.
This error might indicate a memory leak if setState() is being
called because another object is retaining a reference to this
State object after it has been removed from the tree. To avoid
memory leaks, consider breaking the reference to this object
during dispose().
When the exception was thrown, this was the stack:
#0 State.setState.<anonymous closure> (package:flutter/src/widgets/framework.dart:1085:9)
#1 State.setState (package:flutter/src/widgets/framework.dart:1120:6)
#2 _AsyncLoonoLightApiButtonState.build.<anonymous closure> (package:loono/ui/widgets/async_button.dart:186:15)
<asynchronous suspension>
The test description was:
TC(LOON-565): Performing self-examination - Has finding - find
doctor path
```