### PR TITLE
feat: reusable memory storage utility

### DIFF
--- a/lib/ui/screens/find_doctor/find_doctor.dart
+++ b/lib/ui/screens/find_doctor/find_doctor.dart
@@ -14,6 +14,7 @@ import 'package:loono/ui/widgets/find_doctor/main_search_text_field.dart';
 import 'package:loono/ui/widgets/find_doctor/map_preview.dart';
 import 'package:loono/ui/widgets/find_doctor/specialization_chips_list.dart';
 import 'package:loono/utils/map_utils.dart';
+import 'package:loono/utils/memoized_stream.dart';
 import 'package:loono/utils/registry.dart';
 import 'package:loono_api/loono_api.dart';
 import 'package:provider/provider.dart';
@@ -93,12 +94,11 @@ class _FindDoctorScreenState extends State<FindDoctorScreen> {
             )
           : null,
       body: SafeArea(
-        child: StreamBuilder<HealtCareSyncState>(
-          stream: healthcareProviderRepository.healtcareProvidersStream,
-          initialData: healthcareProviderRepository.lastStreamValue,
+        child: MemoizedStreamBuilder<HealthcareSyncState>(
+          memoizedStream: healthcareProviderRepository.healthcareProvidersSyncStateStream,
           builder: (context, snapshot) {
             final healthcareSyncState = snapshot.data;
-            if (healthcareSyncState == HealtCareSyncState.completed &&
+            if (healthcareSyncState == HealthcareSyncState.completed &&
                 !_isHealthCareProvidersInMapService) {
               _setHealthcareProviders();
             }
@@ -158,7 +158,7 @@ class _FindDoctorScreenState extends State<FindDoctorScreen> {
                   ),
                 ],
                 if (!_isHealthCareProvidersInMapService)
-                  if (healthcareSyncState == HealtCareSyncState.error) ...[
+                  if (healthcareSyncState == HealthcareSyncState.error) ...[
                     _buildErrorIndicator(),
                     const Align(
                       alignment: Alignment.bottomLeft,

--- a/lib/utils/memoized_stream.dart
+++ b/lib/utils/memoized_stream.dart
@@ -2,12 +2,14 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+typedef OnStateChanged<T> = void Function(T state);
+
 class MemoizedStream<T> {
   MemoizedStream(Stream<T> inputStream) : stream = inputStream.asBroadcastStream() {
     stream.listen((newItem) => lastItem = newItem);
   }
 
-  late T lastItem;
+  T? lastItem;
   final Stream<T> stream;
 }
 
@@ -22,4 +24,24 @@ class MemoizedStreamBuilder<T> extends StreamBuilder<T> {
           stream: memoizedStream.stream,
           key: key,
         );
+}
+
+class MemoryStorage<T> {
+  MemoryStorage({T? withInitialValue, this.onStateChanged}) {
+    stateStream = MemoizedStream(_stateController.stream);
+    if (withInitialValue != null) setState(withInitialValue);
+  }
+
+  final _stateController = StreamController<T>.broadcast();
+  final OnStateChanged<T>? onStateChanged;
+
+  late final MemoizedStream<T> stateStream;
+
+  /// The current (latest) state of the [MemoryStorage].
+  T? get state => stateStream.lastItem;
+
+  void setState(T newState) {
+    _stateController.add(newState);
+    onStateChanged?.call(newState);
+  }
 }


### PR DESCRIPTION
jen menši přepoužitelná utilita, která využívá `MemoizedStream` a `MemoizedStreamBuilder`, pro managování stavů v appce (alternativa provideru), kde není přístup ke kontextu, například z `repositories`. Vyextrahoval jsem ten z healthcare_repository.dart a použil to rovnou na tom