### PR TITLE
fix: crash when re-launching app from background

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,14 +25,6 @@
             <meta-data
                 android:name="io.flutter.embedding.android.NormalTheme"
                 android:resource="@style/NormalTheme" />
-            <!-- Displays an Android View that continues showing the launch screen
-                 Drawable until Flutter paints its first frame, then this splash
-                 screen fades out. A splash screen is useful to avoid any visual
-                 gap between the end of Android's launch screen and the painting of
-                 Flutter's first frame. -->
-            <meta-data
-                android:name="io.flutter.embedding.android.SplashScreenDrawable"
-                android:resource="@drawable/launch_background" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
Crash se se dá snadno reprodukovat při zapnutém v dev settings 'Neponechat žádné aktivity', když se minimalizuje appka. Po znovu otevření crashnula, takhle by se měla alespoň spustit odznovu.

Fix z:
https://pub.dev/packages/flutter_native_splash#i-got-the-error-a-splash-screen-was-provided-to-flutter-but-this-is-deprecated Nezmiňuje se tam že to vyloženě fixuje tento issue, ale po odstranění se už mi to nestalo.. předtím se to stávalo furt. Pokud to není úplný fix, snad by to mělo aspoň zredukovat počet :D

Btw dle https://github.com/flutter/flutter/issues/94329 by to mělo být fixed už ve frameworku, možná nějaký konflikt mezi tou knihovnou a oficiálním splashem 🤷‍♂️