### PR TITLE
feat(auth): add back anonymized apple email to error message

### DIFF
--- a/lib/services/auth/failures.dart
+++ b/lib/services/auth/failures.dart
@@ -7,7 +7,6 @@ import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 
 part 'failures.freezed.dart';
 
-const _anonymizedAppleEmailDomain = 'privaterelay.appleid.com';
 const _appleLoginNotSupportedErrCode = '0x00';
 
 extension AuthFailureMessageExt on AuthFailure {
@@ -22,11 +21,7 @@ extension AuthFailureMessageExt on AuthFailure {
       },
       noMessage: () => '',
       accountNotExists: (socialAccount) {
-        var email = socialAccount.email;
-        if (email?.endsWith(_anonymizedAppleEmailDomain) == true) {
-          // this email with such domain will not say to the user anything
-          email = null;
-        }
+        final email = socialAccount.email;
         return '${context.l10n.auth_account_not_exists_message} ${email == null ? '' : '($email).'}';
       },
       network: (message) => message ?? context.l10n.auth_network_failure_message,


### PR DESCRIPTION
Jana testovala sign in with Apple mezi více devices a funguje to (my sice apple email cachujem jen lokálně, ale naštěstí [Keychain syncuje sám Apple mezi devices](https://support.apple.com/en-us/HT204085)), takže o starost míň :D

Jen teda může být edge case že na 1 devicu nám email řekne ale na druhým anonymizuje (xyz@privaterelay.appleid.com). Proto tam vracím tu hlášku o neexistujícím xyz emailu i když je ten email random, aby jim to případně došlo if it makes sense