### PR TITLE
fix(ui): showing zero points award from undergone examination

### DIFF
--- a/lib/helpers/examination_types.dart
+++ b/lib/helpers/examination_types.dart
@@ -10,13 +10,24 @@ extension ExaminationTypeExt on ExaminationType {
     switch (this) {
       case ExaminationType.GENERAL_PRACTITIONER:
       case ExaminationType.GYNECOLOGIST:
+      case ExaminationType.DERMATOLOGIST:
         return 200;
       case ExaminationType.DENTIST:
+      case ExaminationType.UROLOGIST:
         return 300;
-      // TODO: Add the rest of ExaminationTypes
-      default:
+      case ExaminationType.COLONOSCOPY:
+        return 1000;
+      case ExaminationType.MAMMOGRAM:
+      case ExaminationType.TOKS:
+        return 500;
+      case ExaminationType.OPHTHALMOLOGIST:
+      case ExaminationType.ULTRASOUND_BREAST:
+        return 100;
+      case ExaminationType.VENEREAL_DISEASES:
+        // TODO: Handle this case.
         return 0;
     }
+    return 0;
   }
 
   ExaminationTypeUnion get mapToUnion {

--- a/lib/ui/screens/prevention/examination_detail/examination_detail.dart
+++ b/lib/ui/screens/prevention/examination_detail/examination_detail.dart
@@ -344,6 +344,8 @@ class _ExaminationDetailState extends State<ExaminationDetail> {
                                         widget.categorizedExamination.examination.examinationType,
                                         _sex,
                                         widget.categorizedExamination.examination.uuid,
+                                        awardPoints:
+                                            widget.categorizedExamination.examination.points,
                                       );
                                     },
                                   ),

--- a/lib/ui/widgets/prevention/examination_confirm_sheet.dart
+++ b/lib/ui/widgets/prevention/examination_confirm_sheet.dart
@@ -22,8 +22,9 @@ void showConfirmationSheet(
   BuildContext context,
   ExaminationType examinationType,
   Sex sex,
-  String? uuid,
-) {
+  String? uuid, {
+  int? awardPoints,
+}) {
   final practitioner =
       procedureQuestionTitle(context, examinationType: examinationType).toLowerCase();
   final preposition = czechPreposition(context, examinationType: examinationType);
@@ -71,7 +72,7 @@ void showConfirmationSheet(
                       AchievementRoute(
                         header: getAchievementTitle(context, examinationType),
                         textLines: [l10n.award_desc],
-                        numberOfPoints: examinationType.awardPoints,
+                        numberOfPoints: awardPoints ?? examinationType.awardPoints,
                         itemPath: getAchievementAssetPath(examinationType),
                         onButtonTap: _completedAction,
                       ),


### PR DESCRIPTION
po potvrzení že byl/a na prohlídce se u některých doktorů v Award sceeně ukázalo, že získal 0 bodů
~~(je to hardcodované, ale z API typ `ExaminationRecord` nám počet bodů neposílá)~~ // tak jde to z API, ale nechal jsem to v tom switchi, který se použivá v onboardingu kde není přístup k API :D 

![image](https://user-images.githubusercontent.com/67197047/171843034-f5e4b225-14a2-4445-aa7a-00ee26be94ae.png)
