### PR TITLE
fix(UI): Reverse self exam badges

### DIFF
--- a/lib/helpers/flushbar_message.dart
+++ b/lib/helpers/flushbar_message.dart
@@ -1,6 +1,7 @@
 import 'package:another_flushbar/flushbar.dart';
 import 'package:flutter/material.dart';
 import 'package:loono/constants.dart';
+import 'package:loono/l10n/ext.dart';
 
 Flushbar<dynamic> _showFlushBar(BuildContext context, String message, Color bgColor) {
   return Flushbar<dynamic>(
@@ -40,9 +41,30 @@ Object showFlushBarError(
   bool sync = true,
 }) {
   if (message.isEmpty) return Object;
-  if (sync) return _showFlushBar(context, message, LoonoColors.red);
+  if (sync) {
+    return _showFlushBar(
+      context,
+      message,
+      LoonoColors.red,
+    );
+  }
   return Future.delayed(
     const Duration(),
-    () => _showFlushBar(context, message, LoonoColors.red),
+    () => _showFlushBar(
+      context,
+      message,
+      LoonoColors.red,
+    ),
   );
+}
+
+String statusCodeToText(BuildContext context, int? statusCode) {
+  final l10n = context.l10n;
+  var result = l10n.something_went_wrong;
+  switch (statusCode) {
+    case 422:
+      result = l10n.too_early_checkup;
+      break;
+  }
+  return result;
 }

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -1043,5 +1043,7 @@
   "with_support": "Za podpory",
   "@with_support": {},
   "incubated": "Aplikace vznikla\nv inkubátoru",
-  "@incubated": {}
+  "@incubated": {},
+  "too_early_checkup": "Ještě není čas se objednat",
+  "@too_early_checkup": {}
 }

--- a/lib/ui/screens/prevention/examination_detail/examination_detail.dart
+++ b/lib/ui/screens/prevention/examination_detail/examination_detail.dart
@@ -106,7 +106,7 @@ class _ExaminationDetailState extends State<ExaminationDetail> {
         ? DateFormat.yMMMM('cs-CZ').format(
             DateTime(lastVisitDateWithoutDay.year, lastVisitDateWithoutDay.month),
           )
-        : context.l10n.skip_idk;
+        : l10n.skip_idk;
 
     final practitioner =
         procedureQuestionTitle(context, examinationType: _examinationType).toLowerCase();
@@ -128,10 +128,16 @@ class _ExaminationDetailState extends State<ExaminationDetail> {
           Provider.of<ExaminationsProvider>(context, listen: false)
               .updateExaminationsRecord(res.data);
           AutoRouter.of(context).popUntilRouteWithName(ExaminationDetailRoute.name);
-          showFlushBarSuccess(context, context.l10n.checkup_reminder_toast);
+          showFlushBarSuccess(context, l10n.checkup_reminder_toast);
         },
         failure: (err) {
-          showFlushBarError(context, context.l10n.something_went_wrong);
+          showFlushBarError(
+            context,
+            statusCodeToText(
+              context,
+              err.error.response?.statusCode,
+            ),
+          );
         },
       );
     }

--- a/lib/ui/widgets/prevention/self_examination/self_examination_card.dart
+++ b/lib/ui/widgets/prevention/self_examination/self_examination_card.dart
@@ -158,7 +158,7 @@ class SelfExaminationCard extends StatelessWidget {
     required String subtitle,
     bool hasPriority = false,
   }) {
-    final validStatuses = selfExamination.history.reversed.where(
+    final validStatuses = selfExamination.history.where(
       (item) => item == SelfExaminationStatus.COMPLETED || item == SelfExaminationStatus.PLANNED,
     );
 


### PR DESCRIPTION
Odstraněn reverse historie samovyšetření v kartě. 

Zároveň jsem s Radkem testoval 2. samovyšetření a zdá se to být fixrd na BE.

Postup testování:
1. vytvořil jsem první samovyšetření - plannedDate se změnilo na 2022-07-17
2. Radek změnil plannedDate na dnešek
3. appka umožnila udělat 2. samovyšetření a přidělila druhou fajfku v kartě i v detailu

<img width="155" alt="Screenshot 2022-06-17 at 16 13 29" src="https://user-images.githubusercontent.com/19749268/174315660-3d71ad6d-3f34-44d2-83ad-08a3a7679ec3.png">
<img width="179" alt="Screenshot 2022-06-17 at 16 13 47" src="https://user-images.githubusercontent.com/19749268/174315713-caf0da06-7d3a-46a0-87af-9ccfb2659139.png">


