### PR TITLE
fix(tests): revert to old mock interface API

### DIFF
--- a/integration_test/mocks/firebase_auth_mock.dart
+++ b/integration_test/mocks/firebase_auth_mock.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_auth_platform_interface/src/method_channel/method_channel_firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -43,6 +44,7 @@ Future<void> mockFirebaseAuth() async {
 
   final firebaseAuthResponses = Map<String, dynamic>.from(kDefaultFirebaseAuthResponses);
   firebaseAuthChannel.setMockMethodCallHandler((MethodCall methodCall) {
+    debugPrint('firebaseAuthChannel LOG: ${methodCall.toString()}');
     final dynamic response = firebaseAuthResponses[methodCall.method];
     // todo: find better way of handling event channels
     if (response is String Function()) {

--- a/integration_test/mocks/google_sign_in_mock.dart
+++ b/integration_test/mocks/google_sign_in_mock.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_sign_in_platform_interface/google_sign_in_platform_interface.dart';
@@ -27,6 +28,7 @@ void mockGoogleSignIn() {
 
   final googleSignInResponses = Map<String, dynamic>.from(defaultSignInResponse);
   googleSignInMethodChannel.setMockMethodCallHandler((MethodCall methodCall) {
+    debugPrint('googleSignInMethodChannel LOG: ${methodCall.toString()}');
     return Future<dynamic>.value(googleSignInResponses[methodCall.method]);
   });
 }

--- a/lib/services/map_state_sevice.dart
+++ b/lib/services/map_state_sevice.dart
@@ -299,10 +299,7 @@ class MapStateService with ChangeNotifier {
       clusterManager.setItems(allHealthcareProviders.map(HealthcareItemPlace.new).toList());
     } else {
       clusterManager.setItems(
-        allHealthcareProviders
-            .where(_hasSpecialization)
-            .map(HealthcareItemPlace.new)
-            .toList(),
+        allHealthcareProviders.where(_hasSpecialization).map(HealthcareItemPlace.new).toList(),
       );
     }
     notifyListeners();

--- a/lib/services/map_state_sevice.dart
+++ b/lib/services/map_state_sevice.dart
@@ -79,7 +79,7 @@ class MapStateService with ChangeNotifier {
 
   void addAll(Iterable<SimpleHealthcareProvider> healthcareProviders) {
     _allHealthcareProviders.addAll(healthcareProviders);
-    clusterManager.setItems(allHealthcareProviders.map((e) => HealthcareItemPlace(e)).toList());
+    clusterManager.setItems(allHealthcareProviders.map(HealthcareItemPlace.new).toList());
     applyFilter();
     _setSpecializations();
     notifyListeners();
@@ -296,12 +296,12 @@ class MapStateService with ChangeNotifier {
   void setSpecialization(SearchResult? searchResult) {
     currSpecialization = searchResult;
     if (searchResult == null) {
-      clusterManager.setItems(allHealthcareProviders.map((e) => HealthcareItemPlace(e)).toList());
+      clusterManager.setItems(allHealthcareProviders.map(HealthcareItemPlace.new).toList());
     } else {
       clusterManager.setItems(
         allHealthcareProviders
             .where(_hasSpecialization)
-            .map((e) => HealthcareItemPlace(e))
+            .map(HealthcareItemPlace.new)
             .toList(),
       );
     }

--- a/lib/ui/screens/prevention/examination_detail/faq_section.dart
+++ b/lib/ui/screens/prevention/examination_detail/faq_section.dart
@@ -30,7 +30,7 @@ class FaqSection extends StatelessWidget {
           Column(
             children: faqContent(context, examinationType)
                 .map(
-                  (content) => FaqExpansionTile(content),
+                  FaqExpansionTile.new,
                 )
                 .toList(),
           ),

--- a/lib/ui/widgets/find_doctor/map_preview.dart
+++ b/lib/ui/widgets/find_doctor/map_preview.dart
@@ -52,7 +52,7 @@ class MapPreview extends StatelessWidget {
           mapState.setVisibleRegion(latLngBounds);
           mapState.clusterManager
             ..setMapId(mapController.mapId)
-            ..setItems(mapState.allHealthcareProviders.map((e) => HealthcareItemPlace(e)).toList());
+            ..setItems(mapState.allHealthcareProviders.map(HealthcareItemPlace.new).toList());
         },
         onCameraMove: mapState.clusterManager.onCameraMove,
         onCameraIdle: () async {

--- a/lib/utils/registry.dart
+++ b/lib/utils/registry.dart
@@ -160,7 +160,7 @@ Future<void> setup({
 
   registry.registerSingleton<LoonoApi>(LoonoApi(dio: dio));
 
-  registry.registerLazySingleton<GlobalKey<NavigatorState>>(() => GlobalKey());
+  registry.registerLazySingleton<GlobalKey<NavigatorState>>(GlobalKey.new);
   registry.registerLazySingleton<AppConfig>(() => config);
 
   registry.registerSingleton<NotificationService>(NotificationService());
@@ -226,8 +226,8 @@ Future<void> setup({
   registry.registerSingleton<AppRouter>(AppRouter(checkIsLoggedIn: CheckIsLoggedIn()));
 
   // utils
-  registry.registerLazySingleton<ImagePicker>(() => ImagePicker());
-  registry.registerLazySingleton<DefaultCacheManager>(() => DefaultCacheManager());
+  registry.registerLazySingleton<ImagePicker>(ImagePicker.new);
+  registry.registerLazySingleton<DefaultCacheManager>(DefaultCacheManager.new);
 
   // picture caching
   await precacheImagesFromList(welcomeSplashes);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,21 +7,21 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "41.0.0"
+    version: "43.0.0"
   adaptive_dialog:
     dependency: "direct main"
     description:
       name: adaptive_dialog
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.4+2"
+    version: "1.8.0+1"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "4.3.1"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -35,7 +35,7 @@ packages:
       name: animations
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   another_flushbar:
     dependency: "direct main"
     description:
@@ -77,7 +77,7 @@ packages:
       name: auto_route_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "4.2.1"
   badges:
     dependency: "direct main"
     description:
@@ -147,7 +147,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.4.0"
+    version: "8.4.1"
   cached_network_image:
     dependency: "direct main"
     description:
@@ -217,7 +217,7 @@ packages:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.0"
   collection:
     dependency: "direct main"
     description:
@@ -231,7 +231,7 @@ packages:
       name: connectivity_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.5"
+    version: "2.3.6+1"
   connectivity_plus_linux:
     dependency: transitive
     description:
@@ -259,7 +259,7 @@ packages:
       name: connectivity_plus_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.3"
   connectivity_plus_windows:
     dependency: transitive
     description:
@@ -329,7 +329,7 @@ packages:
       name: dbus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.8"
   device_calendar:
     dependency: "direct main"
     description:
@@ -343,42 +343,42 @@ packages:
       name: device_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.1.2"
   device_info_plus_linux:
     dependency: transitive
     description:
       name: device_info_plus_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.0"
   device_info_plus_macos:
     dependency: transitive
     description:
       name: device_info_plus_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.3"
+    version: "3.0.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
       name: device_info_plus_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0+1"
+    version: "3.0.0"
   device_info_plus_web:
     dependency: transitive
     description:
       name: device_info_plus_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.0"
   device_info_plus_windows:
     dependency: transitive
     description:
       name: device_info_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "4.0.0"
   diacritic:
     dependency: "direct main"
     description:
@@ -399,7 +399,7 @@ packages:
       name: dio_smart_retry
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.2"
   drift:
     dependency: "direct main"
     description:
@@ -434,7 +434,7 @@ packages:
       name: email_validator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.17"
   encrypted_moor:
     dependency: "direct main"
     description:
@@ -457,7 +457,7 @@ packages:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "2.0.1"
   file:
     dependency: transitive
     description:
@@ -471,98 +471,98 @@ packages:
       name: firebase_analytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.2.0"
+    version: "9.3.3"
   firebase_analytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_analytics_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.0"
+    version: "3.3.3"
   firebase_analytics_web:
     dependency: transitive
     description:
       name: firebase_analytics_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.2+3"
   firebase_auth:
     dependency: "direct main"
     description:
       name: firebase_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.4.2"
+    version: "3.7.0"
   firebase_auth_platform_interface:
     dependency: "direct dev"
     description:
       name: firebase_auth_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.3.2"
+    version: "6.6.0"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.3.0"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.19.2"
+    version: "1.21.1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.4.3"
+    version: "4.5.1"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.7.2"
   firebase_crashlytics:
     dependency: "direct main"
     description:
       name: firebase_crashlytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.5"
+    version: "2.8.9"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.11"
+    version: "3.2.15"
   firebase_storage:
     dependency: "direct main"
     description:
       name: firebase_storage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "10.3.2"
+    version: "10.3.7"
   firebase_storage_platform_interface:
     dependency: transitive
     description:
       name: firebase_storage_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.11"
+    version: "4.1.15"
   firebase_storage_web:
     dependency: transitive
     description:
       name: firebase_storage_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.5"
   fixnum:
     dependency: transitive
     description:
@@ -654,7 +654,7 @@ packages:
       name: flutter_native_splash
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.4"
+    version: "2.2.8"
   flutter_native_timezone:
     dependency: "direct main"
     description:
@@ -675,21 +675,21 @@ packages:
       name: flutter_secure_storage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.2"
+    version: "5.1.2"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
       name: flutter_secure_storage_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   flutter_secure_storage_macos:
     dependency: transitive
     description:
       name: flutter_secure_storage_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
@@ -717,7 +717,7 @@ packages:
       name: flutter_svg
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1+1"
+    version: "1.1.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -741,14 +741,14 @@ packages:
       name: freezed
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.1.0+1"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.1.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -774,7 +774,7 @@ packages:
       name: geolocator_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "4.1.0"
   geolocator_apple:
     dependency: transitive
     description:
@@ -830,42 +830,42 @@ packages:
       name: google_maps_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.8"
+    version: "2.1.12"
+  google_maps_flutter_android:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.0"
+  google_maps_flutter_ios:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.11"
   google_maps_flutter_platform_interface:
     dependency: transitive
     description:
       name: google_maps_flutter_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.2"
   google_sign_in:
     dependency: "direct main"
     description:
       name: google_sign_in
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.4.0"
-  google_sign_in_android:
-    dependency: transitive
-    description:
-      name: google_sign_in_android
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "6.0.1"
-  google_sign_in_ios:
-    dependency: transitive
-    description:
-      name: google_sign_in_ios
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "5.4.0"
+    version: "5.2.4"
   google_sign_in_platform_interface:
     dependency: "direct dev"
     description:
       name: google_sign_in_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.2"
   google_sign_in_web:
     dependency: transitive
     description:
@@ -893,7 +893,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.4"
+    version: "0.13.5"
   http_multi_server:
     dependency: transitive
     description:
@@ -928,7 +928,7 @@ packages:
       name: image_picker_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.5+1"
+    version: "0.8.5+2"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -942,14 +942,14 @@ packages:
       name: image_picker_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.5+6"
+    version: "0.8.6"
   image_picker_platform_interface:
     dependency: transitive
     description:
       name: image_picker_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   integration_test:
     dependency: "direct dev"
     description: flutter
@@ -1003,7 +1003,7 @@ packages:
       name: lint
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.10.0"
   lints:
     dependency: transitive
     description:
@@ -1033,7 +1033,7 @@ packages:
       name: macos_ui
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.7.4"
   matcher:
     dependency: transitive
     description:
@@ -1103,7 +1103,7 @@ packages:
       name: onesignal_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.2"
+    version: "3.4.1"
   open_store:
     dependency: "direct main"
     description:
@@ -1124,7 +1124,7 @@ packages:
       name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.2"
+    version: "1.4.3+1"
   package_info_plus_linux:
     dependency: transitive
     description:
@@ -1159,7 +1159,7 @@ packages:
       name: package_info_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "2.0.0"
   path:
     dependency: "direct main"
     description:
@@ -1173,14 +1173,14 @@ packages:
       name: path_drawing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   path_parsing:
     dependency: transitive
     description:
       name: path_parsing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   path_provider:
     dependency: "direct main"
     description:
@@ -1194,14 +1194,14 @@ packages:
       name: path_provider_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.16"
+    version: "2.0.20"
   path_provider_ios:
     dependency: transitive
     description:
       name: path_provider_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.10"
+    version: "2.0.11"
   path_provider_linux:
     dependency: transitive
     description:
@@ -1229,7 +1229,7 @@ packages:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.7"
+    version: "2.1.2"
   pedantic:
     dependency: transitive
     description:
@@ -1327,7 +1327,7 @@ packages:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   quiver:
     dependency: transitive
     description:
@@ -1348,14 +1348,14 @@ packages:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.27.4"
+    version: "0.27.5"
   share_plus:
     dependency: "direct main"
     description:
       name: share_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.10"
+    version: "4.0.10+1"
   share_plus_linux:
     dependency: transitive
     description:
@@ -1397,7 +1397,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -1411,7 +1411,7 @@ packages:
       name: sign_in_with_apple
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.1.0"
   sign_in_with_apple_platform_interface:
     dependency: transitive
     description:
@@ -1458,14 +1458,14 @@ packages:
       name: sprintf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0"
+    version: "6.0.2"
   sqflite:
     dependency: transitive
     description:
       name: sqflite
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.3+1"
   sqflite_common:
     dependency: transitive
     description:
@@ -1486,14 +1486,14 @@ packages:
       name: sqlite3
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.2"
+    version: "1.8.0"
   sqlite3_flutter_libs:
     dependency: "direct main"
     description:
       name: sqlite3_flutter_libs
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.8"
+    version: "0.5.9"
   sqlparser:
     dependency: transitive
     description:
@@ -1647,7 +1647,7 @@ packages:
       name: url_launcher_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.12"
+    version: "2.0.13"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -1675,14 +1675,14 @@ packages:
       name: video_player
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.5"
+    version: "2.4.7"
   video_player_android:
     dependency: transitive
     description:
       name: video_player_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.7"
+    version: "2.3.9"
   video_player_avfoundation:
     dependency: transitive
     description:
@@ -1696,14 +1696,14 @@ packages:
       name: video_player_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.3"
+    version: "5.1.4"
   video_player_web:
     dependency: transitive
     description:
       name: video_player_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.10"
+    version: "2.0.12"
   vm_service:
     dependency: transitive
     description:
@@ -1738,14 +1738,14 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.7.0"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0+1"
+    version: "0.2.0+2"
   xml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 version: 0.1.3+4
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   adaptive_dialog: ^1.6.3
@@ -88,6 +88,10 @@ dependencies:
   video_player: ^2.1.10
   yaml: ^3.1.0
   youtube_player_flutter: ^8.0.0
+
+dependency_overrides:
+  google_sign_in: '5.2.4'
+  google_sign_in_platform_interface: '2.1.2'
 
 dev_dependencies:
   auto_route_generator: ^4.2.0


### PR DESCRIPTION
#347 nějak upgradnulo `google_sign_in` package na vyšší verzi, který nepoužívá už` Platform Channely` ale `Pigeon`, takže mocky přestaly fungovat - zobrazoval se ten přihlašovací dialog. Workaround - revertnul jsem verze tak jak byly předtím. Až se bude chtít upgradovat `firebase_auth` a `google_sign_in` tak se budou muset ty mocky přepsat

btw myslím že 2 testy failujou ale blíže jsem nekoukal